### PR TITLE
Change voxel generation to be pull based

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use export::export_image;
 use ray_tracer::{dense::DenseStorage, RayTracer};
-use voxel::generate_voxels;
+use voxel::VoxelGenerator;
 
 pub mod export;
 pub mod ray_tracer;
@@ -9,7 +9,7 @@ pub mod voxel;
 #[tokio::main]
 async fn main() {
     // Create voxel data.
-    let voxel_generator = generate_voxels();
+    let voxel_generator = VoxelGenerator::new();
     // Create ray tracer.
     let ray_tracer = RayTracer::<DenseStorage>::from_voxels(voxel_generator);
     // Run ray tracer.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use export::export_image;
+use glam::IVec3;
 use ray_tracer::{dense::DenseStorage, RayTracer};
 use voxel::VoxelGenerator;
 
@@ -10,8 +11,9 @@ pub mod voxel;
 async fn main() {
     // Create voxel data.
     let voxel_generator = VoxelGenerator::new();
+    let bounds = (IVec3::new(-10, -10, -10), IVec3::new(10, 10, 10));
     // Create ray tracer.
-    let ray_tracer = RayTracer::<DenseStorage>::from_voxels(voxel_generator);
+    let ray_tracer = RayTracer::<DenseStorage>::from_voxels(voxel_generator, bounds);
     // Run ray tracer.
     let fb = ray_tracer.render().await;
     // Export image.

--- a/src/ray_tracer/dense.rs
+++ b/src/ray_tracer/dense.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use glam::UVec3;
+use glam::{IVec3, UVec3};
 
 use crate::voxel::{Voxel, VoxelGenerator};
 
@@ -13,7 +13,7 @@ pub struct DenseStorage {
 }
 
 impl Scene for DenseStorage {
-    fn from_voxels(generator: VoxelGenerator) -> Self {
+    fn from_voxels(generator: VoxelGenerator, bounds: (IVec3, IVec3)) -> Self {
         todo!()
     }
 

--- a/src/ray_tracer/mod.rs
+++ b/src/ray_tracer/mod.rs
@@ -1,3 +1,5 @@
+use glam::IVec3;
+
 use crate::{
     export::Framebuffer,
     voxel::{Voxel, VoxelGenerator},
@@ -11,9 +13,12 @@ pub struct RayTracer<T: Scene> {
 }
 
 impl<T: Scene> RayTracer<T> {
-    pub fn from_voxels(generator: VoxelGenerator) -> Self {
+    /// Creates a ray tracer with a scene from a voxel generator and bounds.
+    ///
+    /// `bounds` represents the `(lower, upper)` bounds that voxels are generated in, where for each dimension1 `lower < higher`.
+    pub fn from_voxels(generator: VoxelGenerator, bounds: (IVec3, IVec3)) -> Self {
         Self {
-            scene: T::from_voxels(generator),
+            scene: T::from_voxels(generator, bounds),
         }
     }
 
@@ -28,7 +33,9 @@ impl<T: Scene> RayTracer<T> {
 /// we can abstract the functionality into a trait.
 pub trait Scene {
     /// Collects voxels from a generator.
-    fn from_voxels(generator: VoxelGenerator) -> Self;
+    ///
+    /// `bounds` represents the `(lower, upper)` bounds that voxels are generated in, where for each dimension1 `lower < higher`.
+    fn from_voxels(generator: VoxelGenerator, bounds: (IVec3, IVec3)) -> Self;
 
     /// TODO: change type signature to include parameters needed.
     fn trace(&self) -> Option<Voxel>;

--- a/src/ray_tracer/octree/mod.rs
+++ b/src/ray_tracer/octree/mod.rs
@@ -1,3 +1,5 @@
+use glam::IVec3;
+
 use crate::voxel::{Voxel, VoxelGenerator};
 
 use super::Scene;
@@ -5,7 +7,7 @@ use super::Scene;
 pub struct Octree {}
 
 impl Scene for Octree {
-    fn from_voxels(generator: VoxelGenerator) -> Self {
+    fn from_voxels(generator: VoxelGenerator, bounds: (IVec3, IVec3)) -> Self {
         todo!()
     }
 

--- a/src/voxel/mod.rs
+++ b/src/voxel/mod.rs
@@ -1,4 +1,4 @@
-use glam::{U8Vec3, UVec3};
+use glam::{IVec3, U8Vec3};
 
 /// Data associated with a single voxel.
 pub struct Voxel {
@@ -9,21 +9,13 @@ pub struct Voxel {
 pub struct VoxelGenerator {}
 
 impl VoxelGenerator {
-    /// Provides a hint about the dimensions of the voxel space.
-    pub fn dims() -> UVec3 {
+    /// Create a new voxel generator.
+    pub fn new() -> Self {
         todo!()
     }
-}
 
-impl Iterator for VoxelGenerator {
-    type Item = Option<Voxel>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Lookup a voxel value at some position.
+    pub fn lookup(&self, pos: IVec3) -> Option<Voxel> {
         todo!()
     }
-}
-
-/// Create a new voxel generator
-pub fn generate_voxels() -> VoxelGenerator {
-    todo!();
 }


### PR DESCRIPTION
To avoid the need for synchronization and redundant looping, this changes the voxel storage creation to be the driver for voxel generation.